### PR TITLE
518 validation for invalid routing paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,28 +1,154 @@
 # EQ Author Validator
 
-This repository contains a library of validation tools for Author, but are designed to be reusable across other projects as well.
+An API for validating surveys.
+
+The validator contains several methods for validating a survey at different **levels**. It allows you to run a series of validation checks on a survey at **page level**, **section level** and **survey level** independently from one-another. In addition to this, you can validate an entire survey at **all levels**, thus validating everything within the survey.
 
 ## Getting Started
 
-These instructions will get you a copy of the project up and running on your local machine for development and testing purposes. See deployment for notes on how to deploy the project on a live system.
-
 ### Prerequisites
 
-* [Node.js](https://nodejs.org/en/)
-* [Yarn](https://yarnpkg.com/en/)
+- [Node.js](https://nodejs.org/en/)
+- [Yarn](https://yarnpkg.com/en/)
 
-## Features
+## API Reference
 
-* Detects cycles in routing rules
-* Detects orphaned pages and questions
+To use the API, import `validator.js` into your module.
+
+All methods require a **ctx** (context) and **errors** object. The **ctx** object is the object returned from querying the Author API to retrieve an entire survey, and the errors object will contain the output of the validation checks.
+
+```
+const errors = {
+      errors: []
+    };
+```
+
+Some validation checks may require you to pass in an **options** object when calling the validator to set certain configurations. Information on if this is needed will be provided, but currently there are **no settings** you need to pass in.
+
+### validatePage()
+
+_Args: page!, ctx!, errors!, options_
+
+Conducts **page level** validation checks, and returns the errors object containing a list of errors if any are found.
+
+```
+const { get } = require("lodash");
+const { validatePage } = require("path/to/validator.js");
+const ctx = require("path/to/survey/JSON");
+
+const page = get(ctx, "data.questionnaire.sections[0].pages[0]");
+
+const errors = {
+      errors: []
+};
+
+console.log(validatePage(page, ctx, errors));
+```
+
+### validateSection()
+
+_Args: section!, ctx!, errors!, options_
+
+Conducts **section level** validation checks, and returns the errors object containing a list of errors if any are found.
+
+```
+const { get } = require("lodash");
+const { validateSection } = require("path/to/validator.js");
+const ctx = require("path/to/survey/JSON");
+
+const section = get(ctx, "data.questionnaire.sections[0]");
+
+const errors = {
+      errors: []
+};
+
+console.log(validatePage(section, ctx, errors));
+```
+
+### validateSurvey()
+
+_Args: ctx!, errors!, options_
+
+Conducts **survey level** validation checks, and returns the errors object containing a list of errors if any are found.
+
+```
+const { get } = require("lodash");
+const { validateSurvey } = require("path/to/validator.js");
+const ctx = require("path/to/survey/JSON");
+
+const errors = {
+      errors: []
+};
+
+console.log(validateSurvey(ctx, errors));
+```
+
+### validateEverything()
+
+_Args: ctx!, errors!, options_
+
+Calls `validateSurvey()`, `validateSection()` for every section in a survey and `validatePage()` for every page in a section, and throws an error displaying the errors object if any errors are found. This method fails fast after each function call.
+
+```
+const { get } = require("lodash");
+const { validateEverything } = require("path/to/validator.js");
+const ctx = require("path/to/survey/JSON");
+
+const errors = {
+      errors: []
+};
+
+console.log(validateEverything(ctx, errors));
+```
+
+## Contributing
+
+### Folder structure
+
+```
+.
+├── fixtures             # Mock survey data for use in tests
+├── node_modules
+├── src                  # Source files
+├──── graphlib_demo
+├──── helpers            # Helper files, e.g. script to build a survey as a directed graph
+├──── features           # Validation scripts
+├──── validator.js       # API methods
+├── .eslintrc            # eslint config
+├── .gitignore
+├── .travis.yml          # travis config
+├── LICENSE
+├── package.json
+├── README.md
+├── yarn.lock
+```
+
+### Adding a Script
+
+Your script should be housed beneath `ROOT/src/scripts/` and then either `page`, `section` or `survey`, depending on which level of the survey your script will run. For example, if your script detects whether a page is orphaned, this is a **page level** validation and therefore housed under `ROOT/src/scripts/page`. Your script should be placed in its own folder, named after the script.
+
+The script must be exported as a node module and imported into `validation.js`, and so it can be reused in other projects where possible.
+
+`validation.js` contains three methods: `validateSurvey(questionnaireData)`, `validateSection(survey, section, firstQuestion)`, `validatePage(survey, page, firstQuestion)`. Each method is built so that it can be ran independently, but all call its child method. For example, `validateSurvey()` calls `validateSection()`, which calls `validatePage()`, but `validatePage()` can be called without `validateSurvey()` and `validateSection()` if necessary.
+
+Your script should be imported into `validation.js` and called inside the correct method. There is a specific place to call your script within each method: these are marked by comments.
+
+### Adding a test
+
+You must add a test for your script. All tests are housed in `validation.test.js`, as we are testing `validation.js` as well as your script.
+
+You must provide invalid dummy data for your test. This should be housed in the same directory as your script and called `test-data.invalid.js`; context for this file is supplied by its file path. You can create dummy data by building a survey, with the error your script should pick up, in Author and querying the API afterwards. Remember to import your dummy data into `validation.test.js`. Where possible, you should attempt to modify `ROOT/src/test-data.valid.js` programatically instead.
+
+Valid test data is provided within the project, this is: `ROOT/src/test-data.valid.js`. This should already be imported into `validation.test.js`.
 
 ## Running the tests
 
-Run `yarn test` in the console, from the root directory.
+Run `yarn test` in the console, from the root directory. Currently, we have **Jest** and **Eslint** tests.
 
 ## Built With
 
-* [Graphlib](https://github.com/dagrejs/graphlib) - Used in detecting cycles in routing rules, and orphaned questions or sections.
+- [Graphlib](https://github.com/dagrejs/graphlib) - used for creating a directed graph structure to represent routing paths through a survey.
+- [Lodash](https://lodash.com/docs/4.17.10)
 
 ## License
 

--- a/fixtures/routing/survey-with-orphan-page.json
+++ b/fixtures/routing/survey-with-orphan-page.json
@@ -1,0 +1,283 @@
+{
+  "data": {
+    "questionnaire": {
+      "id": "2",
+      "title": "Hummus",
+      "description": "",
+      "theme": "default",
+      "legalBasis": "StatisticsOfTradeAct",
+      "navigation": true,
+      "surveyId": "",
+      "summary": true,
+      "sections": [
+        {
+          "id": "2",
+          "title": "",
+          "description": "",
+          "pages": [
+            {
+              "id": "5",
+              "title": "<p>Do you like hummus?</p>",
+              "description": "",
+              "guidance": null,
+              "pageType": "QuestionPage",
+              "routingRuleSet": {
+                "id": "4",
+                "else": {
+                  "__typename": "LogicalDestination",
+                  "logicalDestination": "NextPage"
+                },
+                "routingRules": [
+                  {
+                    "id": "5",
+                    "operation": "And",
+                    "goto": {
+                      "__typename": "LogicalDestination",
+                      "logicalDestination": "NextPage"
+                    },
+                    "conditions": [
+                      {
+                        "id": "5",
+                        "comparator": "Equal",
+                        "answer": {
+                          "id": "5",
+                          "type": "Radio",
+                          "options": [
+                            {
+                              "id": "7",
+                              "label": "yes"
+                            },
+                            {
+                              "id": "8",
+                              "label": "no"
+                            }
+                          ],
+                          "other": null
+                        },
+                        "routingValue": {
+                          "value": ["7"]
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              "answers": [
+                {
+                  "id": "5",
+                  "type": "Radio",
+                  "label": "",
+                  "description": "",
+                  "guidance": "",
+                  "properties": {
+                    "required": false
+                  },
+                  "qCode": "",
+                  "options": [
+                    {
+                      "id": "7",
+                      "label": "yes",
+                      "description": "",
+                      "value": "",
+                      "qCode": ""
+                    },
+                    {
+                      "id": "8",
+                      "label": "no",
+                      "description": "",
+                      "value": "",
+                      "qCode": ""
+                    }
+                  ],
+                  "other": null
+                }
+              ]
+            },
+            {
+              "id": "6",
+              "title": "<p>What do you like about hummus?</p>",
+              "description": "",
+              "guidance": null,
+              "pageType": "QuestionPage",
+              "routingRuleSet": {
+                "id": "5",
+                "else": {
+                  "__typename": "AbsoluteDestination",
+                  "absoluteDestination": {
+                    "id": "8",
+                    "__typename": "QuestionPage"
+                  }
+                },
+                "routingRules": [
+                  {
+                    "id": "6",
+                    "operation": "And",
+                    "goto": {
+                      "__typename": "AbsoluteDestination",
+                      "absoluteDestination": {
+                        "id": "8",
+                        "__typename": "QuestionPage"
+                      }
+                    },
+                    "conditions": [
+                      {
+                        "id": "6",
+                        "comparator": "Equal",
+                        "answer": {
+                          "id": "6",
+                          "type": "Radio",
+                          "options": [
+                            {
+                              "id": "9",
+                              "label": "Everything"
+                            },
+                            {
+                              "id": "10",
+                              "label": "It makes me happy"
+                            },
+                            {
+                              "id": "11",
+                              "label": "The taste"
+                            },
+                            {
+                              "id": "12",
+                              "label": "The texture"
+                            }
+                          ],
+                          "other": null
+                        },
+                        "routingValue": {
+                          "value": []
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              "answers": [
+                {
+                  "id": "6",
+                  "type": "Radio",
+                  "label": "",
+                  "description": "",
+                  "guidance": "",
+                  "properties": {
+                    "required": false
+                  },
+                  "qCode": "",
+                  "options": [
+                    {
+                      "id": "9",
+                      "label": "Everything",
+                      "description": "",
+                      "value": "",
+                      "qCode": ""
+                    },
+                    {
+                      "id": "10",
+                      "label": "It makes me happy",
+                      "description": "",
+                      "value": "",
+                      "qCode": ""
+                    },
+                    {
+                      "id": "11",
+                      "label": "The taste",
+                      "description": null,
+                      "value": null,
+                      "qCode": null
+                    },
+                    {
+                      "id": "12",
+                      "label": "The texture",
+                      "description": null,
+                      "value": null,
+                      "qCode": null
+                    }
+                  ],
+                  "other": null
+                }
+              ]
+            },
+            {
+              "id": "7",
+              "title": "<p>Why do you not like hummus?</p>",
+              "description": "",
+              "guidance": null,
+              "pageType": "QuestionPage",
+              "routingRuleSet": null,
+              "answers": [
+                {
+                  "id": "7",
+                  "type": "Radio",
+                  "label": "",
+                  "description": "",
+                  "guidance": "",
+                  "properties": {
+                    "required": false
+                  },
+                  "qCode": "",
+                  "options": [
+                    {
+                      "id": "13",
+                      "label": "Kidding, I think hummus is great",
+                      "description": "",
+                      "value": "",
+                      "qCode": ""
+                    },
+                    {
+                      "id": "14",
+                      "label": "It doesn't taste nice",
+                      "description": "",
+                      "value": "",
+                      "qCode": ""
+                    },
+                    {
+                      "id": "15",
+                      "label": "The texture is weird",
+                      "description": null,
+                      "value": null,
+                      "qCode": null
+                    }
+                  ],
+                  "other": null
+                }
+              ]
+            },
+            {
+              "id": "8",
+              "title": "<p>What is your date of birth?</p>",
+              "description": "",
+              "guidance": null,
+              "pageType": "QuestionPage",
+              "routingRuleSet": null,
+              "answers": [
+                {
+                  "id": "8",
+                  "type": "DateRange",
+                  "label": "Date of birth",
+                  "description": "",
+                  "guidance": "",
+                  "properties": {
+                    "required": false
+                  },
+                  "qCode": "",
+                  "childAnswers": [
+                    {
+                      "id": "8from",
+                      "label": "Date of birth"
+                    },
+                    {
+                      "id": "8to",
+                      "label": null
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/fixtures/valid-survey.json
+++ b/fixtures/valid-survey.json
@@ -1,0 +1,322 @@
+{
+  "data": {
+    "questionnaire": {
+      "id": "1",
+      "title": "Cheese",
+      "description": "",
+      "theme": "default",
+      "legalBasis": "StatisticsOfTradeAct",
+      "navigation": false,
+      "surveyId": "",
+      "summary": false,
+      "sections": [
+        {
+          "id": "1",
+          "title": "",
+          "description": "",
+          "pages": [
+            {
+              "id": "1",
+              "title": "<p>Do you like cheese?</p>",
+              "description": "",
+              "guidance": null,
+              "pageType": "QuestionPage",
+              "routingRuleSet": {
+                "id": "2",
+                "else": {
+                  "__typename": "AbsoluteDestination",
+                  "absoluteDestination": {
+                    "id": "4",
+                    "__typename": "QuestionPage"
+                  }
+                },
+                "routingRules": [
+                  {
+                    "id": "2",
+                    "operation": "And",
+                    "goto": {
+                      "__typename": "LogicalDestination",
+                      "logicalDestination": "NextPage"
+                    },
+                    "conditions": [
+                      {
+                        "id": "2",
+                        "comparator": "Equal",
+                        "answer": {
+                          "id": "1",
+                          "type": "Radio",
+                          "options": [
+                            {
+                              "id": "1",
+                              "label": "yes"
+                            },
+                            {
+                              "id": "2",
+                              "label": "no"
+                            }
+                          ],
+                          "other": null
+                        },
+                        "routingValue": {
+                          "value": ["1"]
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "id": "3",
+                    "operation": "And",
+                    "goto": {
+                      "__typename": "AbsoluteDestination",
+                      "absoluteDestination": {
+                        "id": "3",
+                        "__typename": "QuestionPage"
+                      }
+                    },
+                    "conditions": [
+                      {
+                        "id": "3",
+                        "comparator": "Equal",
+                        "answer": {
+                          "id": "1",
+                          "type": "Radio",
+                          "options": [
+                            {
+                              "id": "1",
+                              "label": "yes"
+                            },
+                            {
+                              "id": "2",
+                              "label": "no"
+                            }
+                          ],
+                          "other": null
+                        },
+                        "routingValue": {
+                          "value": ["2"]
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              "answers": [
+                {
+                  "id": "1",
+                  "type": "Radio",
+                  "label": "",
+                  "description": "",
+                  "guidance": "",
+                  "properties": {
+                    "required": false
+                  },
+                  "qCode": "",
+                  "options": [
+                    {
+                      "id": "1",
+                      "label": "yes",
+                      "description": "",
+                      "value": "",
+                      "qCode": ""
+                    },
+                    {
+                      "id": "2",
+                      "label": "no",
+                      "description": "",
+                      "value": "",
+                      "qCode": ""
+                    }
+                  ],
+                  "other": null
+                }
+              ]
+            },
+            {
+              "id": "2",
+              "title": "<p>Why do you like cheese?</p>",
+              "description": "",
+              "guidance": null,
+              "pageType": "QuestionPage",
+              "routingRuleSet": {
+                "id": "1",
+                "else": {
+                  "__typename": "AbsoluteDestination",
+                  "absoluteDestination": {
+                    "id": "4",
+                    "__typename": "QuestionPage"
+                  }
+                },
+                "routingRules": [
+                  {
+                    "id": "1",
+                    "operation": "And",
+                    "goto": {
+                      "__typename": "AbsoluteDestination",
+                      "absoluteDestination": {
+                        "id": "4",
+                        "__typename": "QuestionPage"
+                      }
+                    },
+                    "conditions": [
+                      {
+                        "id": "1",
+                        "comparator": "Equal",
+                        "answer": {
+                          "id": "2",
+                          "type": "Radio",
+                          "options": [
+                            {
+                              "id": "3",
+                              "label": "It's lovely"
+                            },
+                            {
+                              "id": "4",
+                              "label": "I'm a big fan of the moon"
+                            }
+                          ],
+                          "other": null
+                        },
+                        "routingValue": {
+                          "value": []
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              "answers": [
+                {
+                  "id": "2",
+                  "type": "Radio",
+                  "label": "",
+                  "description": "",
+                  "guidance": "",
+                  "properties": {
+                    "required": false
+                  },
+                  "qCode": "",
+                  "options": [
+                    {
+                      "id": "3",
+                      "label": "It's lovely",
+                      "description": "",
+                      "value": "",
+                      "qCode": ""
+                    },
+                    {
+                      "id": "4",
+                      "label": "I'm a big fan of the moon",
+                      "description": "",
+                      "value": "",
+                      "qCode": ""
+                    }
+                  ],
+                  "other": null
+                }
+              ]
+            },
+            {
+              "id": "3",
+              "title": "<p>Why do you not like cheese?</p>",
+              "description": "",
+              "guidance": null,
+              "pageType": "QuestionPage",
+              "routingRuleSet": {
+                "id": "3",
+                "else": {
+                  "__typename": "LogicalDestination",
+                  "logicalDestination": "NextPage"
+                },
+                "routingRules": [
+                  {
+                    "id": "4",
+                    "operation": "And",
+                    "goto": {
+                      "__typename": "LogicalDestination",
+                      "logicalDestination": "NextPage"
+                    },
+                    "conditions": [
+                      {
+                        "id": "4",
+                        "comparator": "Equal",
+                        "answer": {
+                          "id": "3",
+                          "type": "Radio",
+                          "options": [
+                            {
+                              "id": "5",
+                              "label": "I'm vegan"
+                            },
+                            {
+                              "id": "6",
+                              "label": "It smells"
+                            }
+                          ],
+                          "other": null
+                        },
+                        "routingValue": {
+                          "value": []
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              "answers": [
+                {
+                  "id": "3",
+                  "type": "Radio",
+                  "label": "",
+                  "description": "",
+                  "guidance": "",
+                  "properties": {
+                    "required": false
+                  },
+                  "qCode": "",
+                  "options": [
+                    {
+                      "id": "5",
+                      "label": "I'm vegan",
+                      "description": "",
+                      "value": "",
+                      "qCode": ""
+                    },
+                    {
+                      "id": "6",
+                      "label": "It smells",
+                      "description": "",
+                      "value": "",
+                      "qCode": ""
+                    }
+                  ],
+                  "other": null
+                }
+              ]
+            },
+            {
+              "id": "4",
+              "title": "<p>What is your name?</p>",
+              "description": "",
+              "guidance": null,
+              "pageType": "QuestionPage",
+              "routingRuleSet": null,
+              "answers": [
+                {
+                  "id": "4",
+                  "type": "TextField",
+                  "label": "Name",
+                  "description": "",
+                  "guidance": "",
+                  "properties": {
+                    "required": false
+                  },
+                  "qCode": ""
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/src/demos/graphlib.test.js
+++ b/src/demos/graphlib.test.js
@@ -1,10 +1,15 @@
 const graphlib = require("graphlib");
-const { intersection, isEmpty } = require("lodash");
+const { isEmpty } = require("lodash");
 
-const findOrphanedQuestion = (nodesWithoutOutEdges, nodesWithoutInEdges) =>
-  !isEmpty(intersection(nodesWithoutInEdges, nodesWithoutOutEdges));
+const isOrphaned = (id, firstQuestion, graph) => {
+  if (isEmpty(graph.inEdges(id)) && id !== firstQuestion) {
+    return true;
+  }
 
-describe("Routing Rules", () => {
+  return false;
+};
+
+describe("graphLib Functionality", () => {
   let survey;
   beforeEach(() => {
     survey = new graphlib.Graph();
@@ -52,25 +57,10 @@ describe("Routing Rules", () => {
   });
 
   it("should recognise an orphaned question", () => {
-    survey.setNode("7", "What is your date of birth?");
-
-    const nodesWithoutOutEdges = survey.sinks();
-    const nodesWithoutInEdges = survey.sources();
-
-    expect(
-      findOrphanedQuestion(nodesWithoutOutEdges, nodesWithoutInEdges)
-    ).toBe(true);
+    expect(isOrphaned(6, 1, survey)).toBe(true);
   });
 
   it("should not flag up an error for orphaned questions when there are none", () => {
-    survey.setEdge("5", "6");
-    survey.setEdge("4", "6");
-
-    const nodesWithoutOutEdges = survey.sinks();
-    const nodesWithoutInEdges = survey.sources();
-
-    expect(
-      findOrphanedQuestion(nodesWithoutOutEdges, nodesWithoutInEdges)
-    ).toBe(false);
+    expect(isOrphaned(2, 1, survey)).toBe(false);
   });
 });

--- a/src/features/routing/detect-orphan.js
+++ b/src/features/routing/detect-orphan.js
@@ -1,0 +1,13 @@
+const { isEmpty, get } = require("lodash");
+const { levels, newError } = require("../../helpers/error");
+
+module.exports = (id, ctx, graph) => {
+  if (
+    isEmpty(graph.inEdges(id)) &&
+    id !== get(ctx, "data.questionnaire.sections[0].pages[0].id")
+  ) {
+    return newError(levels.WARN, "Orphaned destination detected", {
+      page: id
+    });
+  }
+};

--- a/src/features/routing/detect-orphan.test.js
+++ b/src/features/routing/detect-orphan.test.js
@@ -1,0 +1,34 @@
+const detectOrphan = require("./detect-orphan");
+
+describe("Detect orphaned pages or sections", () => {
+  it("Throws an error if an orphaned page has been found", () => {
+    const graph = {
+      inEdges: jest.fn().mockReturnValue([])
+    };
+    const data = {
+      data: {
+        questionnaire: {
+          sections: [{ pages: [{ id: 1 }] }]
+        }
+      }
+    };
+    expect(detectOrphan(2, data, graph)).toEqual({
+      level: "WARN",
+      message: "Orphaned destination detected",
+      detail: { page: 2 }
+    });
+  });
+  it("Does not throw an error if an orphaned page has not been found", () => {
+    const graph = {
+      inEdges: jest.fn().mockReturnValue({ v: 1, w: 2 })
+    };
+    const data = {
+      data: {
+        questionnaire: {
+          sections: [{ pages: [{ id: 1 }] }]
+        }
+      }
+    };
+    expect(detectOrphan(2, data, graph)).toBeUndefined();
+  });
+});

--- a/src/helpers/build-routing-graph.js
+++ b/src/helpers/build-routing-graph.js
@@ -1,0 +1,60 @@
+const graphlib = require("graphlib");
+const { isNil, get } = require("lodash");
+
+const setEdgeFromRoutingRule = (survey, nextPageId, destination, pageId) => {
+  switch (get(destination, "__typename")) {
+    case "LogicalDestination": {
+      const logicalDestination = get(destination, "logicalDestination");
+      if (logicalDestination === "NextPage") {
+        survey.setEdge(pageId, nextPageId);
+      }
+      break;
+    }
+    case "AbsoluteDestination": {
+      const absoluteDestinationId = get(destination, "absoluteDestination.id");
+      survey.setEdge(pageId, absoluteDestinationId);
+      break;
+    }
+    default:
+      throw new Error(
+        `Routing destination ${get(destination, "__typename")} not recognised`
+      );
+  }
+};
+
+const buildSection = (survey, section) => {
+  const pages = section.pages;
+  pages.forEach((page, i) => {
+    survey.setNode(page.id, page.title.replace(/(<([^>]+)>)/gi, ""));
+
+    if (isNil(pages[i + 1])) {
+      return;
+    }
+
+    const nextPageId = pages[i + 1].id;
+    if (isNil(page.routingRuleSet)) {
+      return survey.setEdge(page.id, nextPageId);
+    } else {
+      get(page, "routingRuleSet.routingRules").forEach(rule => {
+        setEdgeFromRoutingRule(survey, nextPageId, rule.goto, page.id);
+      });
+      setEdgeFromRoutingRule(
+        survey,
+        nextPageId,
+        page.routingRuleSet.else,
+        page.id
+      );
+    }
+  });
+};
+
+module.exports = questionnaireData => {
+  const survey = new graphlib.Graph({ directed: true });
+  survey.setGraph(get(questionnaireData, "data.questionnaire.title"));
+  const sections = get(questionnaireData, "data.questionnaire.sections");
+  sections.forEach(section => {
+    buildSection(survey, section);
+  });
+
+  return survey;
+};

--- a/src/helpers/error.js
+++ b/src/helpers/error.js
@@ -1,0 +1,18 @@
+const levels = {
+  ERR: "ERR",
+  WARN: "WARN",
+  INFO: "INFO"
+};
+
+const newError = (level, message, detail) => {
+  return {
+    level: level,
+    message: message,
+    detail: detail
+  };
+};
+
+Object.assign(module.exports, {
+  levels,
+  newError
+});

--- a/src/validator.js
+++ b/src/validator.js
@@ -1,0 +1,74 @@
+const { get, isNil } = require("lodash");
+const buildRoutingGraph = require("../src/helpers/build-routing-graph");
+const detectOrphan = require("./features/routing/detect-orphan");
+
+const failFast = errors => {
+  if (errors.errors.length > 0) {
+    throw new Error(JSON.stringify(errors, null, 2));
+  }
+};
+
+const validatePage = (
+  page,
+  ctx,
+  errors = {
+    errors: []
+  },
+  graph = buildRoutingGraph(ctx)
+) => {
+  //Call your page-level validation scripts here
+  const orphanError = detectOrphan(page.id, ctx, graph);
+  if (!isNil(orphanError)) {
+    errors.errors.push(orphanError);
+  }
+
+  return errors;
+};
+
+const validateSection = (
+  section,
+  ctx,
+  errors = {
+    errors: []
+  }
+) => {
+  //Call your section-level validation scripts here
+  return errors;
+};
+
+const validateSurvey = (
+  ctx,
+  errors = {
+    errors: []
+  }
+) => {
+  //Call your survey level validation scripts here
+  return errors;
+};
+
+const validateEverything = (
+  ctx,
+  errors = {
+    errors: []
+  }
+) => {
+  errors = validateSurvey(ctx, errors);
+  const graph = buildRoutingGraph(ctx);
+  failFast(errors);
+  get(ctx, "data.questionnaire.sections").forEach(section => {
+    errors = validateSection(section, ctx, errors);
+    failFast(errors);
+    section.pages.forEach(page => {
+      errors = validatePage(page, ctx, errors, graph);
+      failFast(errors);
+    });
+  });
+  return errors;
+};
+
+Object.assign(module.exports, {
+  validatePage,
+  validateSection,
+  validateSurvey,
+  validateEverything
+});

--- a/src/validator.test.js
+++ b/src/validator.test.js
@@ -1,0 +1,15 @@
+const { validateEverything } = require("./validator");
+const validTestData = require("../fixtures/valid-survey.json");
+const orphanedPageTestData = require("../fixtures/routing/survey-with-orphan-page.json");
+
+describe("Validation Script", () => {
+  it("Wont throw an error if there aren't any", () => {
+    const errors = {
+      errors: []
+    };
+    expect(() => validateEverything(validTestData, errors)).not.toThrow();
+  });
+  it("Will throw an error if there is one", () => {
+    expect(() => validateEverything(orphanedPageTestData)).toThrow();
+  });
+});


### PR DESCRIPTION
### What is the context of this PR?

To implement an algorithm for detecting orphaned questions in surveys, after a user has added routing paths. The Trello card asked for cycles in routing paths also, but this has been removed for now as the front-end does not allow for this to happen as of yet.

I have added a folder structure and built the code to allow for future validation scripts to be added as easily as possible.

### How do I review this?

All of the Jest tests should pass and any improvements to the folder structure or code, where possible, should be reported.